### PR TITLE
renamed searcher-proxy to searcher-direct and added a new folder for …

### DIFF
--- a/contracts/searcher-direct/FastLaneSearcherDirect.sol
+++ b/contracts/searcher-direct/FastLaneSearcherDirect.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.16;
 import { ReentrancyGuard } from "solmate/utils/ReentrancyGuard.sol";
 import "openzeppelin-contracts/contracts/utils/Strings.sol";
 
-abstract contract FastLaneSearcherProxyContract is ReentrancyGuard {
+abstract contract FastLaneSearcherDirectContract is ReentrancyGuard {
 
     address public owner;
     address payable private PFLAuction;
@@ -106,7 +106,7 @@ abstract contract FastLaneSearcherProxyContract is ReentrancyGuard {
      }
 }
 
-contract SearcherContractExample is FastLaneSearcherProxyContract {
+contract SearcherContractExample is FastLaneSearcherDirectContract {
     // Your own MEV contract / functions here 
     // NOTE: its security checks must be compatible w/ calls from the FastLane Auction Contract
 


### PR DESCRIPTION
renamed searcher-proxy to searcher-direct and added a new folder for searcher-proxy. The 'searcher-proxy' contract acts as a standalone contract that's meant to call contracts for which the searcher might not own or have modification/control priveleges over (IE if theyre trading via the uniswap V3 router, they can use a proxy contract to submit FastLane searcher transactions that call the uni v3 router). Meanwhile, 'searcher-direct' is very similar, but with the key distinction being that the fastLaneCall then calls address(this) directly rather than an external address.