### PR TITLE
Fix access control issues

### DIFF
--- a/contracts/auction-handler/FastLaneAuctionHandler.sol
+++ b/contracts/auction-handler/FastLaneAuctionHandler.sol
@@ -347,7 +347,7 @@ contract FastLaneAuctionHandler is FastLaneAuctionHandlerEvents, Ownable, Reentr
     /// @notice Pays the validator their outstanding balance
     /// @dev Callable by either validator address, their payee address (if not changed recently), or PFL.
     /// @param _validator Validator address
-    function payValidator(address _validator) external whenNotPaused nonReentrant onlyValidatorProxy(_validator) returns (uint256) {        
+    function payValidator(address _validator) external nonReentrant onlyValidatorProxy(_validator) returns (uint256) {        
         uint256 payableBalance = validatorsBalanceMap[_validator];
         if (payableBalance <= 0) revert RelayCannotBeZero();
 

--- a/contracts/auction-handler/FastLaneAuctionHandler.sol
+++ b/contracts/auction-handler/FastLaneAuctionHandler.sol
@@ -538,8 +538,8 @@ contract FastLaneAuctionHandler is FastLaneAuctionHandlerEvents, Ownable, Reentr
         // Address never seen before in validatorsDataMap -> impossible to have balance / proxy
         if (validatorsDataMap[_validator].payee == address(0)) revert RelayPermissionUnauthorized();
 
-        // Validator or owner or valid payee
-        if (msg.sender != _validator && msg.sender != owner() && !isValidPayee(_validator, msg.sender)) revert RelayPermissionUnauthorized();
+        // Validator or valid payee
+        if (msg.sender != _validator && !isValidPayee(_validator, msg.sender)) revert RelayPermissionUnauthorized();
         _;
     }
 

--- a/test/PFL_AuctionHandler.t.sol
+++ b/test/PFL_AuctionHandler.t.sol
@@ -470,6 +470,22 @@ contract PFLAuctionHandlerTest is PFLHelper, FastLaneAuctionHandlerEvents {
         PFR.payValidator(vm.addr(3333));
 
     }
+
+    function testWithdrawStillEnabledWhenPaused() public {
+        revert();
+    }
+
+    function testValidatorCanSetPayee() public {
+        revert();
+    }
+
+    function testValidatorsPayeeCanSetPayee() public {
+        revert();
+    }
+
+    function testPFLCannotSetValidatorsPayee() public {
+        revert();
+    }
 }
 
 // Fake opportunity to backrun

--- a/test/PFL_AuctionHandler.t.sol
+++ b/test/PFL_AuctionHandler.t.sol
@@ -23,6 +23,11 @@ import "contracts/auction-handler/FastLaneAuctionHandler.sol";
 import { SearcherContractExample } from "contracts/searcher-direct/FastLaneSearcherDirect.sol";
 
 contract PFLAuctionHandlerTest is PFLHelper, FastLaneAuctionHandlerEvents {
+
+    // TODO consider moving addrs to PFLAuction or another helper
+    address constant PAYEE1 = address(0x8881);
+    address constant PAYEE2 = address(0x8882);
+
     FastLaneAuctionHandler PFR;
     BrokenUniswap brokenUniswap;
     address PFL_VAULT = OPS_ADDRESS;
@@ -476,7 +481,16 @@ contract PFLAuctionHandlerTest is PFLHelper, FastLaneAuctionHandlerEvents {
     }
 
     function testValidatorCanSetPayee() public {
-        revert();
+        // TODO - general setup - should be moved to setUp()
+        // or another helper to get system into testable state
+        vm.prank(OWNER);
+        PFR.enableRelayValidator(VALIDATOR1, PAYEE1);
+
+        assertEq(PFR.getValidatorPayee(VALIDATOR1), PAYEE1);
+        vm.prank(VALIDATOR1);
+        PFR.updateValidatorPayee(VALIDATOR1, PAYEE2);
+
+        assertEq(PFR.getValidatorPayee(VALIDATOR1), PAYEE2);
     }
 
     function testValidatorsPayeeCanSetPayee() public {
@@ -484,7 +498,19 @@ contract PFLAuctionHandlerTest is PFLHelper, FastLaneAuctionHandlerEvents {
     }
 
     function testPFLCannotSetValidatorsPayee() public {
-        revert();
+
+        console.log("owner");
+        console.log(OWNER);
+        console.log("validator");
+        console.log(VALIDATOR1);
+        console.log("payee");
+        console.log(PFR.getValidatorPayee(VALIDATOR1));
+        
+        vm.prank(OWNER);
+        vm.expectRevert(FastLaneAuctionHandlerEvents.RelayPermissionUnauthorized.selector);
+        PFR.updateValidatorPayee(VALIDATOR1, OWNER); // attempt to change payee to owner
+
+        // revert();
     }
 }
 

--- a/test/PFL_AuctionHandler.t.sol
+++ b/test/PFL_AuctionHandler.t.sol
@@ -485,16 +485,23 @@ contract PFLAuctionHandlerTest is PFLHelper, FastLaneAuctionHandlerEvents {
         // or another helper to get system into testable state
         vm.prank(OWNER);
         PFR.enableRelayValidator(VALIDATOR1, PAYEE1);
-
         assertEq(PFR.getValidatorPayee(VALIDATOR1), PAYEE1);
+
         vm.prank(VALIDATOR1);
         PFR.updateValidatorPayee(VALIDATOR1, PAYEE2);
-
         assertEq(PFR.getValidatorPayee(VALIDATOR1), PAYEE2);
     }
 
     function testValidatorsPayeeCanSetPayee() public {
-        revert();
+        // TODO - general setup - should be moved to setUp()
+        // or another helper to get system into testable state
+        vm.prank(OWNER);
+        PFR.enableRelayValidator(VALIDATOR1, PAYEE1);
+        assertEq(PFR.getValidatorPayee(VALIDATOR1), PAYEE1);
+        
+        vm.prank(PAYEE1);
+        PFR.updateValidatorPayee(VALIDATOR1, PAYEE2);
+        assertEq(PFR.getValidatorPayee(VALIDATOR1), PAYEE2);
     }
 
     function testPFLCannotSetValidatorsPayee() public {

--- a/test/PFL_AuctionHandler.t.sol
+++ b/test/PFL_AuctionHandler.t.sol
@@ -469,11 +469,6 @@ contract PFLAuctionHandlerTest is PFLHelper, FastLaneAuctionHandlerEvents {
         vm.expectEmit(true, true, true, true);
         emit RelayPausedStateSet(true);
         PFR.setPausedState(true);
-         
-
-        vm.expectRevert(FastLaneAuctionHandlerEvents.RelayPermissionPaused.selector);
-        PFR.payValidator(vm.addr(3333));
-
     }
 
     // TODO liability changes to remove PFL from onlyValidatorProxy means PFL cant call payValidator anymore
@@ -503,7 +498,7 @@ contract PFLAuctionHandlerTest is PFLHelper, FastLaneAuctionHandlerEvents {
         emit RelayProcessingPaidValidator(VALIDATOR1, expectedPayAmount, VALIDATOR1);
         uint returnedPayableBalance = PFR.payValidator(VALIDATOR1);
         uint validatorBalanceAfter = PAYEE1.balance;
-        
+
         assertEq(returnedPayableBalance, expectedPayAmount);
         assertEq(validatorBalanceAfter - validatorBalanceBefore, expectedPayAmount);
     }

--- a/test/PFL_AuctionHandler.t.sol
+++ b/test/PFL_AuctionHandler.t.sol
@@ -498,26 +498,22 @@ contract PFLAuctionHandlerTest is PFLHelper, FastLaneAuctionHandlerEvents {
         vm.prank(OWNER);
         PFR.enableRelayValidator(VALIDATOR1, PAYEE1);
         assertEq(PFR.getValidatorPayee(VALIDATOR1), PAYEE1);
-        
+
         vm.prank(PAYEE1);
         PFR.updateValidatorPayee(VALIDATOR1, PAYEE2);
         assertEq(PFR.getValidatorPayee(VALIDATOR1), PAYEE2);
     }
 
     function testPFLCannotSetValidatorsPayee() public {
-
-        console.log("owner");
-        console.log(OWNER);
-        console.log("validator");
-        console.log(VALIDATOR1);
-        console.log("payee");
-        console.log(PFR.getValidatorPayee(VALIDATOR1));
+        // TODO - general setup - should be moved to setUp()
+        // or another helper to get system into testable state
+        vm.prank(OWNER);
+        PFR.enableRelayValidator(VALIDATOR1, PAYEE1);
+        assertEq(PFR.getValidatorPayee(VALIDATOR1), PAYEE1);
         
         vm.prank(OWNER);
         vm.expectRevert(FastLaneAuctionHandlerEvents.RelayPermissionUnauthorized.selector);
         PFR.updateValidatorPayee(VALIDATOR1, OWNER); // attempt to change payee to owner
-
-        // revert();
     }
 }
 


### PR DESCRIPTION
Fixes

- [x] payValidator can be called even when paused
- [x] Contract owner cannot set a validator's payee address, but validators and their payees can

All changes tested