### PR TITLE
added in a check to make sure validators cant change their own rate d…

### DIFF
--- a/contracts/auction-handler/FastLaneAuctionHandler.sol
+++ b/contracts/auction-handler/FastLaneAuctionHandler.sol
@@ -346,6 +346,10 @@ contract FastLaneAuctionHandler is FastLaneAuctionHandlerEvents, ReentrancyGuard
     /// @param refundShare the share in % that should be paid to the validator
     function updateValidatorRefundShare(uint256 refundShare) public validPayee nonReentrant {
         address validator = getValidator();
+
+        // ensure that validators can't insert txs to boost their refund rates during their own blocks
+        require(validator != block.coinbase, "block author's rate is immutable");
+
         validatorsRefundShareMap[validator] = refundShare;
     }
 


### PR DESCRIPTION
Goal of this pr is to give users confidence that the current validator won't do a "just-in-time" min revenue share boost and frontrun the user so-as to collect the maximum refund %